### PR TITLE
fix: Change total meditation output to only formatted

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -51,9 +51,9 @@ module Types
     def video_by_id(id:)
       Video.find(id)
     end
-    
+
     field :all_programs, [ProgramType], null: false, description: "Gets all programs"
-    
+
     def all_programs
       program_facade.programs
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,16 +13,12 @@ class User < ApplicationRecord
 
   def total_meditation_time
     seconds = meditations.sum(:total_sitting_time)
-    time_hash = { }
-    time_hash[:seconds] = seconds
-    formatted_time = format_time(seconds)
-    time_hash[:formatted] = formatted_time
-    time_hash.to_s
+    format_time(seconds)
   end
 
   def average_meditation_time
     seconds = meditations.average(:total_sitting_time).to_i
-    formatted_time = format_time(seconds)
+    format_time(seconds)
   end
 
   def format_time(seconds)
@@ -33,23 +29,23 @@ class User < ApplicationRecord
 
   private
 
-    def add_time_string(time_array)
-      formatted_time_array = []
-      time_array.each_with_index do |time, index|
-        if time.to_i == 1 && index == 0
-          formatted_time_array << (time + " hour")
-        elsif index == 0
-          formatted_time_array << (time + " hours")
-        elsif time.to_i == 1 && index == 1
-          formatted_time_array << (time + " minute")
-        elsif index == 1
-          formatted_time_array << (time + " minutes")
-        elsif time.to_i == 1 && index == 2
-          formatted_time_array << (time + " second")
-        else index == 2
-          formatted_time_array << (time + " seconds")
-        end
+  def add_time_string(time_array)
+    formatted_time_array = []
+    time_array.each_with_index do |time, index|
+      if time.to_i == 1 && index == 0
+        formatted_time_array << (time + " hour")
+      elsif index == 0
+        formatted_time_array << (time + " hours")
+      elsif time.to_i == 1 && index == 1
+        formatted_time_array << (time + " minute")
+      elsif index == 1
+        formatted_time_array << (time + " minutes")
+      elsif time.to_i == 1 && index == 2
+        formatted_time_array << (time + " second")
+      elsif index == 2
+        formatted_time_array << (time + " seconds")
       end
-      formatted_time_array
     end
+    formatted_time_array
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe User, type: :model do
         @user_meditations = create_list(:meditation, 25, user_id: @user.id)
 
         expect(@user.meditations.sum(:total_sitting_time)).to eq(30000)
-        expect(@user.total_meditation_time).to eq("{:seconds=>30000, :formatted=>\"8 hours 20 minutes\"}")
+        expect(@user.total_meditation_time).to eq("8 hours 20 minutes")
       end
 
       it "format_time method converts seconds into readable format" do


### PR DESCRIPTION
## Types of changes made?
  Quickfix, change output of totalMeditationTime to not include seconds and just output string of formatted time
